### PR TITLE
ci: benchmark workflow, pages site, uploads folder

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,77 @@
+name: Mission Benchmark
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - "**/*.miz"
+
+jobs:
+  benchmark:
+    name: Benchmark Mission Files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install afterburner
+        run: pip install git+https://github.com/TylerDOC1776/dcs-afterburner@master
+
+      - name: Find changed .miz files
+        id: changed
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          FILES=$(git diff --name-only --diff-filter=AM origin/${{ github.base_ref }}...HEAD -- '*.miz' | tr '\n' ' ')
+          echo "files=$FILES" >> $GITHUB_OUTPUT
+
+      - name: Generate reports
+        id: report
+        if: steps.changed.outputs.files != ''
+        run: |
+          mkdir -p reports
+          FAILED=0
+          for f in ${{ steps.changed.outputs.files }}; do
+            STEM=$(basename "$f" .miz)
+            echo "Analyzing $f..."
+            afterburner report "$f" --format md > "reports/${STEM}.md"
+            if ! afterburner analyze "$f" --fail-on critical; then
+              FAILED=1
+            fi
+          done
+          echo "$FAILED" > reports/.failed
+          cat reports/*.md > reports/combined.md
+
+      - name: Upload reports
+        if: steps.changed.outputs.files != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-reports
+          path: reports/*.md
+
+      - name: Post PR comment
+        if: steps.changed.outputs.files != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = '## Mission Benchmark Report\n\n' + fs.readFileSync('reports/combined.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+      - name: Fail on critical findings
+        if: steps.changed.outputs.files != ''
+        run: |
+          if [ "$(cat reports/.failed)" = "1" ]; then
+            echo "Critical findings detected. Merge blocked — review the PR comment for details."
+            exit 1
+          fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,155 @@
+name: Deploy Pages
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Generate and Deploy Site
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate index
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          mkdir -p _site
+          python3 << 'PYEOF'
+          import os, pathlib
+
+          repo = os.environ['GITHUB_REPOSITORY']
+          base_url = f"https://raw.githubusercontent.com/{repo}/main"
+          root = pathlib.Path('.')
+
+          folder_order = ['Chops', 'Dropshot', 'uploads']
+          folders = {}
+          for miz in sorted(root.rglob('*.miz')):
+              if '.git' in miz.parts:
+                  continue
+              folder = miz.parts[1] if len(miz.parts) > 2 else '_root'
+              folders.setdefault(folder, []).append(miz)
+
+          total = sum(len(v) for v in folders.values())
+          display_order = [f for f in folder_order if f in folders] + \
+                          [f for f in sorted(folders) if f not in folder_order]
+
+          sections = ''
+          for folder in display_order:
+              files = folders[folder]
+              rows = ''
+              for miz in files:
+                  size_b = miz.stat().st_size
+                  size_kb = size_b / 1024
+                  size_str = f'{size_kb / 1024:.1f} MB' if size_kb >= 1024 else f'{size_kb:.0f} KB'
+                  url = f"{base_url}/{miz.as_posix()}"
+                  rows += f'''
+                    <div class="file-row">
+                      <span class="file-name">{miz.name}</span>
+                      <span class="file-size">{size_str}</span>
+                      <a class="btn-dl" href="{url}" download="{miz.name}">DOWNLOAD</a>
+                    </div>'''
+              sections += f'''
+              <div class="section-hd">// {folder.upper()}</div>
+              <div class="file-panel">{rows}
+              </div>'''
+
+          html = f"""<!DOCTYPE html>
+          <html lang="en">
+          <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Goon Drop Point</title>
+          <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+          <style>
+            *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+            :root {{
+              --bg: #080c12;
+              --panel: #0a1018;
+              --border: #1a3050;
+              --border-hi: #1e6090;
+              --text-dim: #3a5a7a;
+              --text: #7ab0d0;
+              --text-hi: #bde0f0;
+              --accent: #00c8ff;
+              --amber: #ffaa00;
+            }}
+            body {{ background: var(--bg); color: var(--text); font-family: 'Rajdhani', sans-serif; font-size: 15px; line-height: 1.5; min-height: 100vh; }}
+            body::before {{ content: ''; position: fixed; inset: 0; background-image: linear-gradient(rgba(0,170,255,.04) 1px, transparent 1px), linear-gradient(90deg, rgba(0,170,255,.04) 1px, transparent 1px); background-size: 40px 40px; pointer-events: none; z-index: 0; }}
+            body::after {{ content: ''; position: fixed; inset: 0; background: radial-gradient(ellipse at 50% 0%, rgba(0,100,200,.12) 0%, transparent 60%); pointer-events: none; z-index: 0; }}
+
+            header {{ position: relative; z-index: 1; background: var(--panel); border-bottom: 1px solid var(--border-hi); padding: 0 28px; display: flex; align-items: center; justify-content: space-between; height: 60px; }}
+            header::after {{ content: ''; position: absolute; bottom: 0; left: 0; right: 0; height: 1px; background: linear-gradient(90deg, transparent, var(--accent), transparent); opacity: .4; }}
+
+            .brand {{ display: flex; align-items: center; gap: 16px; }}
+            .brand-emblem {{ width: 38px; height: 38px; border: 1px solid var(--border-hi); display: flex; align-items: center; justify-content: center; color: var(--accent); font-family: 'Share Tech Mono', monospace; font-size: 18px; position: relative; }}
+            .brand-emblem::before, .brand-emblem::after {{ content: ''; position: absolute; width: 6px; height: 6px; border-color: var(--accent); border-style: solid; }}
+            .brand-emblem::before {{ top: -1px; left: -1px; border-width: 1px 0 0 1px; }}
+            .brand-emblem::after {{ bottom: -1px; right: -1px; border-width: 0 1px 1px 0; }}
+            .brand-name {{ font-size: 20px; font-weight: 700; letter-spacing: 4px; color: var(--text-hi); text-transform: uppercase; }}
+            .brand-sub {{ font-size: 10px; letter-spacing: 3px; color: var(--text-dim); font-family: 'Share Tech Mono', monospace; }}
+
+            .sys-status {{ display: flex; align-items: center; gap: 6px; font-size: 11px; letter-spacing: 2px; color: var(--accent); font-family: 'Share Tech Mono', monospace; }}
+            .sys-dot {{ width: 6px; height: 6px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 8px var(--accent); }}
+
+            main {{ position: relative; z-index: 1; max-width: 860px; margin: 0 auto; padding: 32px 24px 48px; }}
+
+            .section-hd {{ font-size: 11px; letter-spacing: 3px; color: var(--text-dim); text-transform: uppercase; margin: 28px 0 8px; font-family: 'Share Tech Mono', monospace; }}
+
+            .file-panel {{ background: var(--panel); border: 1px solid var(--border); }}
+
+            .file-row {{ display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-bottom: 1px solid rgba(26,48,80,.5); }}
+            .file-row:last-child {{ border-bottom: none; }}
+
+            .file-name {{ flex: 1; font-size: 13px; font-weight: 600; color: var(--text-hi); font-family: 'Share Tech Mono', monospace; letter-spacing: .5px; }}
+            .file-size {{ font-size: 11px; color: var(--text-dim); letter-spacing: 1px; min-width: 60px; text-align: right; }}
+
+            .btn-dl {{ padding: 5px 14px; background: rgba(0,170,255,.08); border: 1px solid var(--border-hi); color: var(--accent); font-family: 'Rajdhani', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; text-decoration: none; white-space: nowrap; }}
+            .btn-dl:hover {{ background: rgba(0,170,255,.16); }}
+
+            footer {{ margin-top: 40px; padding-top: 14px; border-top: 1px solid var(--border); text-align: center; font-size: 10px; letter-spacing: 2px; color: var(--text-dim); font-family: 'Share Tech Mono', monospace; }}
+          </style>
+          </head>
+          <body>
+          <header>
+            <div class="brand">
+              <div class="brand-emblem">&#9650;</div>
+              <div>
+                <div class="brand-name">Goon Drop Point</div>
+                <div class="brand-sub">MISSION FILE REPOSITORY // IT-DEV-GROUP-6</div>
+              </div>
+            </div>
+            <div class="sys-status"><div class="sys-dot"></div>{total} MISSIONS</div>
+          </header>
+          <main>{sections}
+          </main>
+          <footer>github.com/{repo}</footer>
+          </body>
+          </html>"""
+
+          with open('_site/index.html', 'w') as fh:
+              fh.write(html)
+          print(f"Generated index: {total} missions across {len(folders)} folders")
+          PYEOF
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site/
+
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@
 !Chops/*
 !Dropshot/
 !Dropshot/*
+!uploads/
+!uploads/*.miz
+!uploads/.gitkeep
+!.github/
+!.github/workflows/
+!.github/workflows/*.yml


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` — runs `dcs-afterburner` on any `.miz` in a PR, posts markdown report as a PR comment, blocks merge on critical findings
- Adds `.github/workflows/pages.yml` — regenerates the GitHub Pages mission index on every push to main
- Adds `uploads/` folder as the landing zone for new mission submissions
- Updates `.gitignore` to track `.github/`, `uploads/`, and `.gitkeep`

## How it works

1. Fork, add a `.miz` to `uploads/`, open a PR
2. `benchmark.yml` runs afterburner and posts the report as a comment
3. Critical findings block merge; clean missions land in `uploads/`
4. `pages.yml` regenerates the site index on merge

## After merging

Enable GitHub Pages in repo Settings → Pages → Source: **GitHub Actions**

## Notes

- afterburner: `pip install git+https://github.com/TylerDOC1776/dcs-afterburner@master`
- Pages HTML uses the dark navy/cyan tactical aesthetic (Rajdhani + Share Tech Mono)
- Moving files from `uploads/` to `Chops/` or `Dropshot/` is a separate PR