### PR TITLE
feat: CI benchmark + GitHub Pages deploy

### DIFF
--- a/.github/scripts/gen_site.py
+++ b/.github/scripts/gen_site.py
@@ -1,0 +1,354 @@
+import glob
+import os
+import subprocess
+from datetime import datetime, timezone
+
+import markdown
+
+REPO_ROOT = os.getcwd()
+WEB_DIR = os.path.join(REPO_ROOT, "web")
+REPORTS_DIR = os.path.join(WEB_DIR, "reports")
+RAW_BASE = "https://github.com/IT-Dev-Group-6/goon-drop-point/raw/main"
+
+FOLDERS = ["Chops", "Dropshot", "uploads"]
+
+FONTS = (
+    "https://fonts.googleapis.com/css2?"
+    "family=Rajdhani:wght@400;600;700"
+    "&family=Share+Tech+Mono&display=swap"
+)
+
+CSS = """
+  :root {
+    --bg:     #0a0e1a;
+    --panel:  #0d1526;
+    --border: #1b2d4a;
+    --cyan:   #00c8ff;
+    --cyan2:  #0088bb;
+    --text:   #c8daea;
+    --dim:    #5878a0;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Rajdhani', sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+    min-height: 100vh;
+  }
+  header {
+    padding: 2rem;
+    background: var(--panel);
+    border-bottom: 1px solid var(--border);
+  }
+  .hud-label {
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--dim);
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    margin-bottom: 0.4rem;
+  }
+  h1 {
+    font-size: 2.1rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  main {
+    max-width: 960px;
+    margin: 2rem auto;
+    padding: 0 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  .corner-box {
+    position: relative;
+    padding: 1.5rem;
+    border: 1px solid var(--border);
+    background: var(--panel);
+  }
+  .corner-box::before {
+    content: '';
+    position: absolute;
+    top: -1px; left: -1px;
+    width: 14px; height: 14px;
+    border-top: 2px solid var(--cyan);
+    border-left: 2px solid var(--cyan);
+  }
+  .corner-box::after {
+    content: '';
+    position: absolute;
+    bottom: -1px; right: -1px;
+    width: 14px; height: 14px;
+    border-bottom: 2px solid var(--cyan);
+    border-right: 2px solid var(--cyan);
+  }
+  .section-header {
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--cyan);
+    font-size: 0.8rem;
+    letter-spacing: 0.2em;
+    padding-bottom: 0.75rem;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .mission-list { list-style: none; }
+  .mission-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.55rem 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .mission-item:last-child { border-bottom: none; }
+  .mission-name {
+    font-family: 'Share Tech Mono', monospace;
+    flex: 1;
+  }
+  .mission-size {
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--dim);
+    font-size: 0.85rem;
+    width: 6rem;
+    text-align: right;
+  }
+  .mission-links { display: flex; gap: 0.6rem; }
+  .mission-links a {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.78rem;
+    color: var(--cyan);
+    text-decoration: none;
+    border: 1px solid var(--cyan2);
+    padding: 0.1rem 0.5rem;
+    letter-spacing: 0.04em;
+  }
+  .mission-links a:hover { background: rgba(0,200,255,0.08); }
+  .empty {
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--dim);
+    font-size: 0.85rem;
+  }
+  footer {
+    text-align: center;
+    padding: 2rem;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.72rem;
+    color: var(--dim);
+    letter-spacing: 0.1em;
+    border-top: 1px solid var(--border);
+    margin-top: 1rem;
+  }
+  /* report page extras */
+  .back-link {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--cyan);
+    text-decoration: none;
+    letter-spacing: 0.1em;
+    display: inline-block;
+    margin-bottom: 1.5rem;
+  }
+  .back-link:hover { text-decoration: underline; }
+  .report-body h1, .report-body h2, .report-body h3 {
+    font-family: 'Rajdhani', sans-serif;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 1.5rem 0 0.5rem;
+    color: var(--cyan);
+  }
+  .report-body h1 { font-size: 1.6rem; }
+  .report-body h2 { font-size: 1.2rem; }
+  .report-body h3 { font-size: 1rem; color: var(--text); }
+  .report-body p { margin-bottom: 0.75rem; }
+  .report-body ul, .report-body ol {
+    margin: 0.5rem 0 0.75rem 1.5rem;
+  }
+  .report-body code {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.85em;
+    background: rgba(0,200,255,0.06);
+    padding: 0.1em 0.3em;
+    border: 1px solid var(--border);
+  }
+  .report-body pre {
+    background: #060a14;
+    border: 1px solid var(--border);
+    padding: 1rem;
+    overflow-x: auto;
+    margin-bottom: 1rem;
+  }
+  .report-body pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.82rem;
+  }
+  .report-body table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+  }
+  .report-body th {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.78rem;
+    letter-spacing: 0.1em;
+    color: var(--cyan);
+    border-bottom: 1px solid var(--cyan2);
+    padding: 0.4rem 0.6rem;
+    text-align: left;
+    background: rgba(0,200,255,0.04);
+  }
+  .report-body td {
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid var(--border);
+  }
+"""
+
+INDEX_TMPL = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>IT-Dev-Group-6 // Mission Drop Point</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="{fonts}" rel="stylesheet">
+  <style>{css}</style>
+</head>
+<body>
+  <header>
+    <div class="hud-label">IT-DEV-GROUP-6 // MISSION DROP POINT</div>
+    <h1>Mission Files</h1>
+  </header>
+  <main>
+{sections}
+  </main>
+  <footer>// GENERATED {generated} //</footer>
+</body>
+</html>
+"""
+
+REPORT_TMPL = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{title} // Benchmark Report</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="{fonts}" rel="stylesheet">
+  <style>{css}</style>
+</head>
+<body>
+  <header>
+    <div class="hud-label">BENCHMARK REPORT</div>
+    <h1>{title}</h1>
+  </header>
+  <main>
+    <a class="back-link" href="../index.html">[ &larr; BACK TO INDEX ]</a>
+    <div class="corner-box">
+      <div class="report-body">{content}</div>
+    </div>
+  </main>
+  <footer>// GENERATED {generated} //</footer>
+</body>
+</html>
+"""
+
+
+def fmt_size(n):
+    if n >= 1_048_576:
+        return f"{n / 1_048_576:.1f} MB"
+    return f"{n / 1024:.0f} KB"
+
+
+def run_report(miz_path):
+    result = subprocess.run(
+        ["afterburner", "report", miz_path, "--format", "md"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout
+    return f"# Report Error\n\nFailed to generate report.\n\n```\n{result.stderr.strip()}\n```"
+
+
+def main():
+    os.makedirs(REPORTS_DIR, exist_ok=True)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    missions = {}
+    for folder in FOLDERS:
+        folder_path = os.path.join(REPO_ROOT, folder)
+        if not os.path.isdir(folder_path):
+            missions[folder] = []
+            continue
+        files = sorted(glob.glob(os.path.join(folder_path, "*.miz")))
+        missions[folder] = [(f, os.path.getsize(f)) for f in files]
+
+    for folder, files in missions.items():
+        for miz_path, _ in files:
+            stem = os.path.splitext(os.path.basename(miz_path))[0]
+            print(f"Reporting {miz_path}...")
+            md = run_report(miz_path)
+            html_content = markdown.markdown(md, extensions=["fenced_code", "tables"])
+            report_page = (
+                REPORT_TMPL
+                .replace("{title}", stem)
+                .replace("{fonts}", FONTS)
+                .replace("{css}", CSS)
+                .replace("{content}", html_content)
+                .replace("{generated}", now)
+            )
+            with open(os.path.join(REPORTS_DIR, f"{stem}.html"), "w") as f:
+                f.write(report_page)
+
+    sections_html = ""
+    for folder in FOLDERS:
+        files = missions.get(folder, [])
+        if not files:
+            items_html = f'    <p class="empty">// NO MISSIONS</p>'
+        else:
+            items = []
+            for miz_path, size in files:
+                stem = os.path.splitext(os.path.basename(miz_path))[0]
+                rel = os.path.relpath(miz_path, REPO_ROOT).replace(os.sep, "/")
+                dl_url = f"{RAW_BASE}/{rel}"
+                rpt_url = f"reports/{stem}.html"
+                items.append(
+                    f'      <li class="mission-item">'
+                    f'<span class="mission-name">{stem}.miz</span>'
+                    f'<span class="mission-size">{fmt_size(size)}</span>'
+                    f'<span class="mission-links">'
+                    f'<a href="{dl_url}">[ DOWNLOAD ]</a>'
+                    f'<a href="{rpt_url}">[ REPORT ]</a>'
+                    f"</span></li>"
+                )
+            items_html = "      <ul class=\"mission-list\">\n" + "\n".join(items) + "\n      </ul>"
+
+        sections_html += (
+            f'    <section class="corner-box">\n'
+            f'      <div class="section-header">// {folder.upper()}</div>\n'
+            f"{items_html}\n"
+            f"    </section>\n"
+        )
+
+    index_html = (
+        INDEX_TMPL
+        .replace("{fonts}", FONTS)
+        .replace("{css}", CSS)
+        .replace("{sections}", sections_html)
+        .replace("{generated}", now)
+    )
+    with open(os.path.join(WEB_DIR, "index.html"), "w") as f:
+        f.write(index_html)
+
+    print(f"Site generated in {WEB_DIR}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,151 +5,42 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 on:
   push:
     branches: [main]
 
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
-  deploy:
-    name: Generate and Deploy Site
+  build:
+    name: Build site
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate index
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          mkdir -p _site
-          python3 << 'PYEOF'
-          import os, pathlib
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
-          repo = os.environ['GITHUB_REPOSITORY']
-          base_url = f"https://raw.githubusercontent.com/{repo}/main"
-          root = pathlib.Path('.')
+      - name: Install dependencies
+        run: pip install "git+https://github.com/TylerDOC1776/dcs-afterburner@master" markdown
 
-          folder_order = ['Chops', 'Dropshot', 'uploads']
-          folders = {}
-          for miz in sorted(root.rglob('*.miz')):
-              if '.git' in miz.parts:
-                  continue
-              folder = miz.parts[1] if len(miz.parts) > 2 else '_root'
-              folders.setdefault(folder, []).append(miz)
-
-          total = sum(len(v) for v in folders.values())
-          display_order = [f for f in folder_order if f in folders] + \
-                          [f for f in sorted(folders) if f not in folder_order]
-
-          sections = ''
-          for folder in display_order:
-              files = folders[folder]
-              rows = ''
-              for miz in files:
-                  size_b = miz.stat().st_size
-                  size_kb = size_b / 1024
-                  size_str = f'{size_kb / 1024:.1f} MB' if size_kb >= 1024 else f'{size_kb:.0f} KB'
-                  url = f"{base_url}/{miz.as_posix()}"
-                  rows += f'''
-                    <div class="file-row">
-                      <span class="file-name">{miz.name}</span>
-                      <span class="file-size">{size_str}</span>
-                      <a class="btn-dl" href="{url}" download="{miz.name}">DOWNLOAD</a>
-                    </div>'''
-              sections += f'''
-              <div class="section-hd">// {folder.upper()}</div>
-              <div class="file-panel">{rows}
-              </div>'''
-
-          html = f"""<!DOCTYPE html>
-          <html lang="en">
-          <head>
-          <meta charset="UTF-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          <title>Goon Drop Point</title>
-          <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
-          <style>
-            *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
-            :root {{
-              --bg: #080c12;
-              --panel: #0a1018;
-              --border: #1a3050;
-              --border-hi: #1e6090;
-              --text-dim: #3a5a7a;
-              --text: #7ab0d0;
-              --text-hi: #bde0f0;
-              --accent: #00c8ff;
-              --amber: #ffaa00;
-            }}
-            body {{ background: var(--bg); color: var(--text); font-family: 'Rajdhani', sans-serif; font-size: 15px; line-height: 1.5; min-height: 100vh; }}
-            body::before {{ content: ''; position: fixed; inset: 0; background-image: linear-gradient(rgba(0,170,255,.04) 1px, transparent 1px), linear-gradient(90deg, rgba(0,170,255,.04) 1px, transparent 1px); background-size: 40px 40px; pointer-events: none; z-index: 0; }}
-            body::after {{ content: ''; position: fixed; inset: 0; background: radial-gradient(ellipse at 50% 0%, rgba(0,100,200,.12) 0%, transparent 60%); pointer-events: none; z-index: 0; }}
-
-            header {{ position: relative; z-index: 1; background: var(--panel); border-bottom: 1px solid var(--border-hi); padding: 0 28px; display: flex; align-items: center; justify-content: space-between; height: 60px; }}
-            header::after {{ content: ''; position: absolute; bottom: 0; left: 0; right: 0; height: 1px; background: linear-gradient(90deg, transparent, var(--accent), transparent); opacity: .4; }}
-
-            .brand {{ display: flex; align-items: center; gap: 16px; }}
-            .brand-emblem {{ width: 38px; height: 38px; border: 1px solid var(--border-hi); display: flex; align-items: center; justify-content: center; color: var(--accent); font-family: 'Share Tech Mono', monospace; font-size: 18px; position: relative; }}
-            .brand-emblem::before, .brand-emblem::after {{ content: ''; position: absolute; width: 6px; height: 6px; border-color: var(--accent); border-style: solid; }}
-            .brand-emblem::before {{ top: -1px; left: -1px; border-width: 1px 0 0 1px; }}
-            .brand-emblem::after {{ bottom: -1px; right: -1px; border-width: 0 1px 1px 0; }}
-            .brand-name {{ font-size: 20px; font-weight: 700; letter-spacing: 4px; color: var(--text-hi); text-transform: uppercase; }}
-            .brand-sub {{ font-size: 10px; letter-spacing: 3px; color: var(--text-dim); font-family: 'Share Tech Mono', monospace; }}
-
-            .sys-status {{ display: flex; align-items: center; gap: 6px; font-size: 11px; letter-spacing: 2px; color: var(--accent); font-family: 'Share Tech Mono', monospace; }}
-            .sys-dot {{ width: 6px; height: 6px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 8px var(--accent); }}
-
-            main {{ position: relative; z-index: 1; max-width: 860px; margin: 0 auto; padding: 32px 24px 48px; }}
-
-            .section-hd {{ font-size: 11px; letter-spacing: 3px; color: var(--text-dim); text-transform: uppercase; margin: 28px 0 8px; font-family: 'Share Tech Mono', monospace; }}
-
-            .file-panel {{ background: var(--panel); border: 1px solid var(--border); }}
-
-            .file-row {{ display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-bottom: 1px solid rgba(26,48,80,.5); }}
-            .file-row:last-child {{ border-bottom: none; }}
-
-            .file-name {{ flex: 1; font-size: 13px; font-weight: 600; color: var(--text-hi); font-family: 'Share Tech Mono', monospace; letter-spacing: .5px; }}
-            .file-size {{ font-size: 11px; color: var(--text-dim); letter-spacing: 1px; min-width: 60px; text-align: right; }}
-
-            .btn-dl {{ padding: 5px 14px; background: rgba(0,170,255,.08); border: 1px solid var(--border-hi); color: var(--accent); font-family: 'Rajdhani', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; text-decoration: none; white-space: nowrap; }}
-            .btn-dl:hover {{ background: rgba(0,170,255,.16); }}
-
-            footer {{ margin-top: 40px; padding-top: 14px; border-top: 1px solid var(--border); text-align: center; font-size: 10px; letter-spacing: 2px; color: var(--text-dim); font-family: 'Share Tech Mono', monospace; }}
-          </style>
-          </head>
-          <body>
-          <header>
-            <div class="brand">
-              <div class="brand-emblem">&#9650;</div>
-              <div>
-                <div class="brand-name">Goon Drop Point</div>
-                <div class="brand-sub">MISSION FILE REPOSITORY // IT-DEV-GROUP-6</div>
-              </div>
-            </div>
-            <div class="sys-status"><div class="sys-dot"></div>{total} MISSIONS</div>
-          </header>
-          <main>{sections}
-          </main>
-          <footer>github.com/{repo}</footer>
-          </body>
-          </html>"""
-
-          with open('_site/index.html', 'w') as fh:
-              fh.write(html)
-          print(f"Generated index: {total} missions across {len(folders)} folders")
-          PYEOF
-
-      - uses: actions/configure-pages@v5
+      - name: Generate site
+        run: python .github/scripts/gen_site.py
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: _site/
+          path: web/
 
-      - id: deploy
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@
 !.github/
 !.github/workflows/
 !.github/workflows/*.yml
+!.github/scripts/
+!.github/scripts/*.py
+!web/
+!web/index.html
+!web/reports/
+!web/reports/.gitkeep
+!web/reports/*.html


### PR DESCRIPTION
## Summary

- **`benchmark.yml`** — triggers on PRs touching `.miz` files; installs `dcs-afterburner`, runs `analyze --fail-on critical` and `report --format md` on each changed file, posts a combined markdown report as a PR comment, and blocks merge on critical findings
- **`pages.yml`** + **`gen_site.py`** — triggers on push to main; scans Chops/, Dropshot/, and uploads/ for `.miz` files, generates per-mission benchmark report pages (markdown → HTML) and a dark HUD-styled index with download + report links, deploys to GitHub Pages
- `.gitignore` updated to track `uploads/`, `web/`, `.github/workflows/`, `.github/scripts/`

## Before merging

Enable GitHub Pages in repo Settings → Pages → Source: **GitHub Actions**

## Test plan

- [ ] Open a PR with a `.miz` file change — confirm `benchmark.yml` runs, report appears as PR comment
- [ ] Merge to main — confirm `pages.yml` runs and site deploys
- [ ] Check index page loads with correct folder sections and links
- [ ] Check a report page loads with afterburner output