### PR TITLE
fix: dynamic folder discovery + README upload guide

### DIFF
--- a/.github/scripts/gen_site.py
+++ b/.github/scripts/gen_site.py
@@ -10,7 +10,15 @@ WEB_DIR = os.path.join(REPO_ROOT, "web")
 REPORTS_DIR = os.path.join(WEB_DIR, "reports")
 RAW_BASE = "https://github.com/IT-Dev-Group-6/goon-drop-point/raw/main"
 
-FOLDERS = ["Chops", "Dropshot", "uploads"]
+SKIP_DIRS = {".git", ".github", "pictures", "web"}
+
+
+def discover_folders():
+    entries = sorted(
+        e for e in os.listdir(REPO_ROOT)
+        if os.path.isdir(os.path.join(REPO_ROOT, e)) and e not in SKIP_DIRS
+    )
+    return entries
 
 FONTS = (
     "https://fonts.googleapis.com/css2?"
@@ -281,8 +289,9 @@ def main():
     os.makedirs(REPORTS_DIR, exist_ok=True)
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
+    folders = discover_folders()
     missions = {}
-    for folder in FOLDERS:
+    for folder in folders:
         folder_path = os.path.join(REPO_ROOT, folder)
         if not os.path.isdir(folder_path):
             missions[folder] = []
@@ -308,7 +317,7 @@ def main():
                 f.write(report_page)
 
     sections_html = ""
-    for folder in FOLDERS:
+    for folder in folders:
         files = missions.get(folder, [])
         if not files:
             items_html = f'    <p class="empty">// NO MISSIONS</p>'

--- a/README.md
+++ b/README.md
@@ -1,22 +1,60 @@
-# goon-drop-point
+# Goon Drop Point
 
 <img src="pictures/IT_-_DEV_GROUP_-_6.jpg" alt="IT Dev Group 6" width="200"/>
 
 Shared drop point for DCS World `.miz` mission files used by IT-Dev-Group-6.
 
-## What's here
+---
 
-Raw `.miz` files — no scripts, no docs, just missions. These are working files shared across the group for testing, development, and reference.
+## How to upload a mission file
 
-## Usage
+You don't need to know git. Everything below is done through the GitHub website.
 
-Clone the repo and drop `.miz` files directly in the root. Only `.miz` files are tracked (everything else is gitignored).
+### Step 1 — Create a GitHub account
 
-```bash
-git clone git@github.com:IT-Dev-Group-6/goon-drop-point.git
-```
+If you don't have one, go to [github.com](https://github.com) and sign up. It's free.
+
+### Step 2 — Fork this repo
+
+A **fork** is your own personal copy of the repo where you can make changes.
+
+1. Make sure you're logged in to GitHub
+2. Go to the top of this page and click the **Fork** button (top-right corner)
+3. On the next screen, click **Create fork**
+
+You now have a copy of the repo under your own account.
+
+### Step 3 — Upload your .miz file
+
+1. In your fork, click into the **`uploads`** folder
+2. Click **Add file → Upload files**
+3. Drag your `.miz` file into the box (or click *choose your files*)
+4. Scroll down and click **Commit changes**
+
+### Step 4 — Open a Pull Request
+
+A **pull request** (PR) is how you ask for your file to be added to the main repo.
+
+1. After committing, GitHub will show a yellow banner saying your branch is ahead — click **Contribute → Open pull request**
+   - If you don't see the banner, click the **Pull requests** tab, then **New pull request**
+2. Give it a title like `upload: My Mission Name`
+3. Click **Create pull request**
+
+### Step 5 — Wait for the check to pass
+
+Once you open the PR, an automated benchmark runs on your mission file. This checks for common performance issues.
+
+- A green checkmark ✅ means the file passed — someone will review and merge it
+- A red X ❌ means something needs attention — check the comment on the PR for details
+
+### Step 6 — Done
+
+Once merged, your file will appear on the [mission index page](https://it-dev-group-6.github.io/goon-drop-point/) and be available for the group to download.
+
+---
 
 ## Notes
 
-- `.miz` files are ZIP archives containing Lua tables — open with any ZIP tool or the DCS Mission Editor
-- Don't rename files without coordinating with the group — scripts may reference filenames directly
+- Drop files in `uploads/` — they'll be moved to the right folder after review
+- Don't rename `.miz` files after sharing them — scripts may reference filenames directly
+- `.miz` files are ZIP archives containing Lua — open with any ZIP tool or the DCS Mission Editor


### PR DESCRIPTION
## Summary

- **`gen_site.py`** — replaced hardcoded folder list with `discover_folders()` which scans the repo root and skips `.git`, `.github`, `pictures`, `web`. Any new folder added to the repo now shows up on the Pages site automatically.
- **`README.md`** — complete rewrite with step-by-step upload instructions written for group members with no GitHub experience: account creation, forking, uploading a file, opening a PR, and understanding the benchmark check.

## Test plan

- [ ] Confirm Pages site shows all current folders (Chops, Dropshot, Foothold, Testing, uploads)
- [ ] Add a new folder and verify it appears without any code changes
- [ ] Read through README and confirm instructions are clear end-to-end