### PR TITLE
feat: comment benchmark issue status

### DIFF
--- a/.github/scripts/comment_benchmark_status.py
+++ b/.github/scripts/comment_benchmark_status.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+from datetime import datetime, timezone
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+BENCH_API_BASE = os.environ.get("BENCH_API_BASE", "https://goon.gsquad.cc/api/v1").strip().rstrip("/")
+BENCH_API_KEY = os.environ.get("BENCH_API_KEY", "").strip()
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "").strip()
+GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "").strip()
+FORCE_STATUS_COMMENT = os.environ.get("FORCE_STATUS_COMMENT", "0").lower() in {"1", "true", "yes"}
+
+QUEUE_ID_RE = re.compile(r"\b(bq_[0-9a-f]+)\b")
+RUN_ID_RE = re.compile(r"\b(brun_[0-9a-f]+)\b")
+
+
+def github_json(method, path, data=None):
+    if not GITHUB_TOKEN:
+        raise SystemExit("GITHUB_TOKEN is required")
+    url = f"https://api.github.com/repos/{GITHUB_REPOSITORY}{path}"
+    body = None
+    if data is not None:
+        body = json.dumps(data).encode()
+    request = Request(
+        url,
+        data=body,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {GITHUB_TOKEN}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    with urlopen(request, timeout=60) as response:
+        raw = response.read()
+        return json.loads(raw.decode() or "{}")
+
+
+def bench_json(path):
+    if not BENCH_API_KEY:
+        raise SystemExit("BENCH_API_KEY is required")
+    request = Request(
+        f"{BENCH_API_BASE}{path}",
+        headers={"X-API-Key": BENCH_API_KEY},
+    )
+    with urlopen(request, timeout=60) as response:
+        raw = response.read()
+        return json.loads(raw.decode() or "{}")
+
+
+def list_open_benchmark_issues():
+    query = urlencode({"state": "open", "labels": "benchmark", "per_page": "100"})
+    return github_json("GET", f"/issues?{query}")
+
+
+def list_comments(issue_number):
+    query = urlencode({"per_page": "100"})
+    return github_json("GET", f"/issues/{issue_number}/comments?{query}")
+
+
+def comment(issue_number, body):
+    return github_json("POST", f"/issues/{issue_number}/comments", {"body": body})
+
+
+def queue_items_by_id():
+    items = bench_json("/bench/queue")
+    return {item.get("id"): item for item in items if item.get("id")}
+
+
+def run_details(run_id):
+    try:
+        return bench_json(f"/bench/runs/{run_id}")
+    except (HTTPError, URLError, TimeoutError):
+        return None
+
+
+def extract_queue_ids(comments):
+    ids = []
+    seen = set()
+    for item in comments:
+        for queue_id in QUEUE_ID_RE.findall(item.get("body") or ""):
+            if queue_id not in seen:
+                ids.append(queue_id)
+                seen.add(queue_id)
+    return ids
+
+
+def already_commented_today(comments, marker):
+    if FORCE_STATUS_COMMENT:
+        return False
+    return any(marker in (item.get("body") or "") for item in comments)
+
+
+def fmt_item(item, details):
+    queue_id = item.get("id", "unknown")
+    mission = item.get("miz_filename") or "unknown mission"
+    status = item.get("status") or "unknown"
+    duration = item.get("duration_s")
+    line = f"- `{queue_id}` `{mission}`: **{status}**"
+    if duration:
+        line += f" ({duration}s requested)"
+
+    if item.get("run_id"):
+        line += f", run `{item['run_id']}`"
+
+    if status == "done" and details:
+        bench = details.get("bench_timeseries") or []
+        cpu = details.get("cpu_timeseries") or []
+        findings = details.get("findings") or []
+        line += f" - mission samples {len(bench)}, CPU samples {len(cpu)}, findings {len(findings)}"
+    elif status == "failed" and item.get("error"):
+        error = str(item["error"]).replace("\r", " ").replace("\n", " ")
+        if len(error) > 220:
+            error = error[:217] + "..."
+        line += f" - error: `{error}`"
+    elif status in {"pending", "running"}:
+        line += " - still waiting/running"
+
+    return line
+
+
+def status_body(queue_ids, queue_by_id):
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    marker = f"<!-- benchmark-status:{today} -->"
+    lines = [
+        marker,
+        "## Benchmark Status",
+        "",
+        "Daily 07:02 Eastern queue check.",
+        "",
+    ]
+
+    if not queue_ids:
+        lines.append("No benchmark queue IDs were found in this issue yet.")
+        return "\n".join(lines) + "\n"
+
+    missing = []
+    for queue_id in queue_ids:
+        item = queue_by_id.get(queue_id)
+        if not item:
+            missing.append(queue_id)
+            continue
+        details = run_details(item["run_id"]) if item.get("run_id") else None
+        lines.append(fmt_item(item, details))
+
+    if missing:
+        lines.extend(["", "Queue IDs not found in orchestrator:"])
+        lines.extend(f"- `{queue_id}`" for queue_id in missing)
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    if not GITHUB_REPOSITORY:
+        raise SystemExit("GITHUB_REPOSITORY is required")
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    marker = f"<!-- benchmark-status:{today} -->"
+    queue_by_id = queue_items_by_id()
+    issues = list_open_benchmark_issues()
+
+    for issue in issues:
+        if "pull_request" in issue:
+            continue
+        number = issue["number"]
+        comments = list_comments(number)
+        if already_commented_today(comments, marker):
+            print(f"Skipping issue #{number}: already commented today")
+            continue
+        queue_ids = extract_queue_ids(comments)
+        body = status_body(queue_ids, queue_by_id)
+        comment(number, body)
+        print(f"Commented on issue #{number}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/queue_benchmarks.py
+++ b/.github/scripts/queue_benchmarks.py
@@ -153,6 +153,15 @@ def queue_file(path):
 def write_summary(results, errors):
     lines = ["## Benchmark Queue Request", ""]
     if results:
+        lines.extend(
+            [
+                "The mission file(s) below were added to the benchmark queue.",
+                "",
+                "Expected run window: roughly 02:00-07:00 Eastern the next morning.",
+                "A scheduled status check posts benchmark results back here every morning at 07:02 Eastern.",
+                "",
+            ]
+        )
         lines.extend(["Queued mission file(s):", ""])
         for result in results:
             item = result["item"]

--- a/.github/workflows/benchmark-status.yml
+++ b/.github/workflows/benchmark-status.yml
@@ -1,0 +1,28 @@
+name: Benchmark Issue Status
+
+on:
+  schedule:
+    # 07:02 Eastern during daylight saving time. GitHub cron is UTC.
+    - cron: "2 11 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  status:
+    name: Comment benchmark issue status
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Comment benchmark status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCH_API_KEY: ${{ secrets.DCS_BENCH_API_KEY }}
+        run: python .github/scripts/comment_benchmark_status.py

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ When the issue is opened, edited, or labeled with `benchmark`, GitHub Actions wi
 
 New `.miz` files merged into `main` also create a `benchmark` issue automatically and queue the new mission file(s).
 
+The queue comment lists the generated queue IDs and the expected run window. Benchmarks usually run overnight, roughly 02:00-07:00 Eastern the next morning. A scheduled GitHub Action checks open `benchmark` issues every morning at 07:02 Eastern and comments with the latest queue/run status.
+
 Repository setup required:
 
 - Secret `DCS_BENCH_API_KEY`: orchestrator API key used to create queue items


### PR DESCRIPTION
Added in that branch:

  - Trim/strip env vars before queueing, so newline issues cannot poison future queue rows.
  - Queue comment now tells the user:
      - files were added to the queue
      - expected run window is roughly 02:00-07:00 Eastern next morning
      - daily status check posts at 07:02 Eastern
  - New scheduled workflow: .github/workflows/benchmark-status.yml
      - runs daily at 11:02 UTC (07:02 Eastern during daylight saving time)
      - can also be run manually
      - checks open benchmark issues
      - finds queue IDs from prior comments
      - comments current status/results back on the issue

