### PR TITLE
fix: don't trigger immediate run after queue by default

### DIFF
--- a/.github/scripts/queue_benchmarks.py
+++ b/.github/scripts/queue_benchmarks.py
@@ -16,7 +16,7 @@ API_KEY = os.environ.get("BENCH_API_KEY", "")
 HOST_ID = os.environ.get("BENCH_HOST_ID", "host_1ad3930ed744")
 INSTANCE_ID = os.environ.get("BENCH_INSTANCE_ID", "DCS-TexasBBQ")
 DURATION_S = os.environ.get("BENCH_DURATION_S", "1800")
-RUN_NOW = os.environ.get("BENCH_RUN_NOW", "1").lower() not in {"0", "false", "no"}
+RUN_NOW = os.environ.get("BENCH_RUN_NOW", "0").lower() not in {"0", "false", "no"}
 SUMMARY_PATH = os.environ.get("BENCH_QUEUE_SUMMARY", "bench-queue-summary.md")
 
 MIZ_REF_RE = re.compile(r"(?P<ref>(?:https?://[^\s)>\]\"']+|[\w./@%+ -]+?\.miz))", re.IGNORECASE)


### PR DESCRIPTION
RUN_NOW defaulted to true, causing the first queued mission to fire a /run request immediately instead of waiting for the 02:00-07:00 window.