### PR TITLE
fix: create bench report when no existing md file

### DIFF
--- a/.github/scripts/refresh_bench_reports.py
+++ b/.github/scripts/refresh_bench_reports.py
@@ -279,14 +279,11 @@ def main():
     processed = 0
     for stem, data in benches.items():
         report_path = REPORTS_DIR / f"{stem}.md"
-        if not report_path.exists():
-            print(f"Skipping {stem}: no existing report markdown")
-            continue
-
-        existing = report_path.read_text()
+        existing = report_path.read_text() if report_path.exists() else ""
+        action = "Created" if not existing else "Updated"
         report_path.write_text(merge_markdown(existing, bench_markdown(data)))
         processed += 1
-        print(f"Updated {report_path}")
+        print(f"{action} {report_path}")
 
     print(f"Updated {processed} report(s).")
     return 0

--- a/.github/workflows/refresh-reports.yml
+++ b/.github/workflows/refresh-reports.yml
@@ -21,6 +21,17 @@ jobs:
       - name: Install afterburner
         run: pip install git+https://github.com/IT-Dev-Group-6/dcs-afterburner@master
 
+      - name: Generate reports for missions without one
+        run: |
+          mkdir -p reports
+          find . -name "*.miz" -not -path "./.git/*" | while read f; do
+            STEM=$(basename "$f" .miz)
+            if [ ! -f "reports/${STEM}.md" ]; then
+              echo "Generating report for $STEM"
+              afterburner report "$f" --format md > "reports/${STEM}.md"
+            fi
+          done
+
       - name: Fetch bench results
         run: python .github/scripts/fetch_bench_results.py
 


### PR DESCRIPTION
## Summary
- `refresh_bench_reports.py` was skipping any mission that didn't already have a `reports/<stem>.md` file
- New missions merged via PR got bench-results JSON committed but no report markdown, so pages showed "No benchmark report available yet."
- Fix: treat a missing `.md` as empty and create it instead of skipping

## Test plan
- [ ] Merge this, then trigger `Refresh Bench Pages` (workflow_dispatch or wait for tomorrow's 7:02 AM schedule)
- [ ] Verify `reports/Vietguam3B4.md`, `reports/Foothold_AF_0.0.97.md`, and the other 5 missing files are created
- [ ] Verify pages show bench data for issue #29 missions